### PR TITLE
Ability to add multiple sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ module.exports = {
         apiKey: 'GOOGLE_API_KEY',
         spreadsheets: [
           {
-            spreadsheetid: 'SPREADSHEET_ID',
+            spreadsheetId: 'SPREADSHEET_ID',
             sheets: [
               {
                 sheetName: 'SHEET_NAME', // Example: "Sheet1"
@@ -54,9 +54,9 @@ module.exports = {
 ### How to Use Multiple Spreadsheets
 
 ```js
-spreadsheets: [
+options.spreadsheets: [
   {
-    spreadsheetid: 'SPREADSHEET_ID_1',
+    spreadsheetId: 'SPREADSHEET_ID_1',
     sheets: [
       {
         sheetName: 'SHEET_NAME', // Example: "Sheet1"
@@ -65,7 +65,7 @@ spreadsheets: [
     ],
   },
   {
-    spreadsheetid: 'SPREADSHEET_ID_2',
+    spreadsheetId: 'SPREADSHEET_ID_2',
     sheets: [
       {
         sheetName: 'SHEET_NAME', // Example: "Sheet1"
@@ -79,9 +79,9 @@ spreadsheets: [
 ### How to Use Multiple Sheets from the Same Spreadsheet
 
 ```js
-spreadsheets: [
+options.spreadsheets: [
   {
-    spreadsheetid: 'SPREADSHEET_ID',
+    spreadsheetId: 'SPREADSHEET_ID',
     sheets: [
       {
         sheetName: 'SHEET_NAME', // Example: "Sheet1"
@@ -98,14 +98,17 @@ spreadsheets: [
 
 ### Example query on page template
 
+This plugin assumes that the first row in your table is the column name. In this example the 2 columns that exist are named `title` and `body`, with `id` being a key that this plugin generates automatically.
+
 ```js
 <page-query>
   query {
     allCollectionName {
       edges {
         node {
-          id
-          title
+          id, // Automatically generated
+          title,
+          body
         }
       }
     }
@@ -115,14 +118,14 @@ spreadsheets: [
 
 ### To use data in page
 
+`$page.allCollectionName.edges` will be an array of each row of your Google Sheet.
+
 ```js
 <template>
-  <div>
-    {{ $page.allGoogleSheet.node.id }}
-  </div>
-  <div>
-    {{ $page.allGoogleSheet.node.title }}
-  </div>
+    <!--  Example: "{{ $page.allUsers.edges }}" -->
+    <div v-for="row in $page.allCollectionName.edges" v-key="row.node.id">
+      {{ row.node.id }}
+    </div>
 </template>
 ```
 
@@ -137,37 +140,49 @@ module.exports = {
     {
       use: 'gridsome-source-google-sheets',
       options: {
-        sheetId: 'GOOGLE_SHEET_ID',
         apiKey: 'GOOGLE_API_KEY',
-        // type: 'TYPE_NAME', //Optional - default is googleSheet. Used for graphql queries.
+        spreadsheets: [
+          {
+            spreadsheetId: 'SPREADSHEET_ID',
+            sheets: [
+              {
+                sheetName: 'SHEET_NAME', // Example: "Sheet1"
+                collectionName: 'COLLECTION_NAME', // Example: "Users" (Must be unique)
+              },
+            ],
+          },
+        ],
       },
     },
   ],
   templates: {
-    googleSheet: [
+    collectionName: [
       {
-        path: '/:id',
-        component: './src/templates/googleSheet.vue',
+        path: '/somePath/:id', // Example: "/user/:id"
+        component: './src/templates/collectionName.vue', // Example: "./src/templates/users.vue"
       },
     ],
   },
 }
 ```
 
-### Example template in src/template/googleSheet.vue
+### Example template in src/template/collectionName.vue
 
 ```js
 <template>
   <layout>
-    <div>{{$page.googleSheet.title}}</div>
-    <div>{{$page.googleSheet.body}}</div>
+    <!--  Example: "{{ $page.users.title }}" -->
+    <div>{{ $page.collectionName.title }}</div>
+
+    <!--  Example: "{{ $page.users.body }}" -->
+    <div>{{ $page.collectionName.body }}</div>
   </layout>
 </template>
 
 <page-query>
-query Post ($path: String!) {
-  googleSheet (path: $path) {
-    title
+query ($id: ID!) {
+  collectionName(id: $id) { // Example: "users(id: $id)"
+    title,
     body
   }
 }

--- a/README.md
+++ b/README.md
@@ -4,26 +4,27 @@
 ![npm](https://img.shields.io/npm/dt/gridsome-source-google-sheets.svg)
 ![NPM](https://img.shields.io/npm/l/gridsome-source-google-sheets.svg)
 
-Source plugin for fetching data from Google Sheets. 
+Source plugin for fetching data from Google Sheets.
 
 ## Requirements
 
 Gridsome: >0.7.0
 
-## Install 
+## Install
 
 ```js
 yarn add gridsome-source-google-sheets
 ```
+
 npm
+
 ```js
 npm install gridsome-source-google-sheets
 ```
 
 ## How to use
 
-You will need to generate a google api key [here](https://console.developers.google.com/apis/credentials). The sheetId 
-can be found on the sheets url. It is the large hash number near the end. You will also need to make your spreadsheet viewable to the public to use the api credentials.
+You will need to generate a google api key [here](https://console.developers.google.com/apis/credentials). The Spreadsheet ID can be found on the sheets url. You will also need to make your spreadsheet viewable to the public to use the api credentials.
 
 ```js
 module.exports = {
@@ -32,21 +33,75 @@ module.exports = {
     {
       use: 'gridsome-source-google-sheets',
       options: {
-        sheetId: 'GOOGLE_SHEET_ID', 
         apiKey: 'GOOGLE_API_KEY',
-        // type: 'TYPE_NAME', //Optional - default is googleSheet. Used for graphql queries.
-      }
-    }
-  ]
+        spreadsheets: [
+          {
+            spreadsheetid: 'SPREADSHEET_ID',
+            sheets: [
+              {
+                sheetName: 'SHEET_NAME',
+                collectionName: 'COLLECTION_NAME',
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
 }
+```
+
+### How to Use Multiple Spreadsheets
+
+```js
+spreadsheets: [
+  {
+    spreadsheetid: 'SPREADSHEET_ID_1',
+    sheets: [
+      {
+        sheetName: "SHEET_NAME", // "Sheet1"
+        collectionName: "UNIQUE_COLLECTION_NAME" // "Users" (Must be Unique)
+      }
+    ]
+  },
+  {
+    spreadsheetid: 'SPREADSHEET_ID_2',
+    sheets: [
+      {
+        sheetName: "SHEET_NAME", // "Sheet1"
+        collectionName: "COLLECTION_NAME" // "Projects" (Must be unique)
+      }
+    ]
+  }
+],
+```
+
+### How to Use Multiple Sheets from the Same Spreadsheet
+
+```js
+spreadsheets: [
+  {
+    spreadsheetid: 'SPREADSHEET_ID',
+    sheets: [
+      {
+        sheetName: 'SHEET_NAME', // "Sheet1"
+        collectionName: 'COLLECTION_NAME', // "Projects" (Must be unique)
+      },
+      {
+        sheetName: 'SHEET_NAME', // "Sheet2"
+        collectionName: 'COLLECTION_NAME', // "Users" (Must be Unique)
+      },
+    ],
+  },
+]
 ```
 
 ### Example query on page template
 
 ```js
 <page-query>
-  query MyData {
-    allGoogleSheet {
+  query {
+    allCollectionName {
       edges {
         node {
           id
@@ -82,22 +137,21 @@ module.exports = {
     {
       use: 'gridsome-source-google-sheets',
       options: {
-        sheetId: 'GOOGLE_SHEET_ID', 
+        sheetId: 'GOOGLE_SHEET_ID',
         apiKey: 'GOOGLE_API_KEY',
         // type: 'TYPE_NAME', //Optional - default is googleSheet. Used for graphql queries.
-      }
-    }
+      },
+    },
   ],
   templates: {
     googleSheet: [
       {
         path: '/:id',
-        component: './src/templates/googleSheet.vue'
-      }
-    ]
-  }
+        component: './src/templates/googleSheet.vue',
+      },
+    ],
+  },
 }
-
 ```
 
 ### Example template in src/template/googleSheet.vue
@@ -119,8 +173,3 @@ query Post ($path: String!) {
 }
 </page-query>
 ```
-
-## Limitations
-
-* Max columns 52
-* Max rows 10000

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ module.exports = {
             spreadsheetid: 'SPREADSHEET_ID',
             sheets: [
               {
-                sheetName: 'SHEET_NAME',
-                collectionName: 'COLLECTION_NAME',
+                sheetName: 'SHEET_NAME', // Example: "Sheet1"
+                collectionName: 'COLLECTION_NAME', // Example: "Users" (Must be unique)
               },
             ],
           },
@@ -59,21 +59,21 @@ spreadsheets: [
     spreadsheetid: 'SPREADSHEET_ID_1',
     sheets: [
       {
-        sheetName: "SHEET_NAME", // "Sheet1"
-        collectionName: "UNIQUE_COLLECTION_NAME" // "Users" (Must be Unique)
-      }
-    ]
+        sheetName: 'SHEET_NAME', // Example: "Sheet1"
+        collectionName: 'COLLECTION_NAME', // Example: "Users" (Must be unique)
+      },
+    ],
   },
   {
     spreadsheetid: 'SPREADSHEET_ID_2',
     sheets: [
       {
-        sheetName: "SHEET_NAME", // "Sheet1"
-        collectionName: "COLLECTION_NAME" // "Projects" (Must be unique)
-      }
-    ]
-  }
-],
+        sheetName: 'SHEET_NAME', // Example: "Sheet1"
+        collectionName: 'COLLECTION_NAME', // Example: "Projects" (Must be unique)
+      },
+    ],
+  },
+]
 ```
 
 ### How to Use Multiple Sheets from the Same Spreadsheet
@@ -84,12 +84,12 @@ spreadsheets: [
     spreadsheetid: 'SPREADSHEET_ID',
     sheets: [
       {
-        sheetName: 'SHEET_NAME', // "Sheet1"
-        collectionName: 'COLLECTION_NAME', // "Projects" (Must be unique)
+        sheetName: 'SHEET_NAME', // Example: "Sheet1"
+        collectionName: 'COLLECTION_NAME', // Example: "Projects" (Must be unique)
       },
       {
-        sheetName: 'SHEET_NAME', // "Sheet2"
-        collectionName: 'COLLECTION_NAME', // "Users" (Must be Unique)
+        sheetName: 'SHEET_NAME', // Example: "Sheet2"
+        collectionName: 'COLLECTION_NAME', // Example: "Users" (Must be Unique)
       },
     ],
   },


### PR DESCRIPTION
Essentially this does the same as the previous plugin version, but now you can add the spreadsheets as an array of objects to load the data from each spreadsheet.

Another thing to note: I changed the name of `sheetId` to `spreadsheetId` so it was closer to the google specs and since sheetId is already a thing (which maybe could be iterated through as well).

I can also update the readme.