### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ module.exports = {
       options: {
         sheetId: 'GOOGLE_SHEET_ID', 
         apiKey: 'GOOGLE_API_KEY',
+        route: 'OPTIONAL_ROUTE', //Optional - omit if not using routes
         type: 'TYPE_NAME', //Optional - default is googleSheet. Used for graphql queries.
+      }
     }
   ]
 }


### PR DESCRIPTION
it was inconvenient for copy and paste. so added `}` at the end of `options`

+ accidentally added `route` option. 