### PR TITLE
Expose an option for range

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ module.exports = {
       options: {
         sheetId: 'GOOGLE_SHEET_ID', 
         apiKey: 'GOOGLE_API_KEY',
-        // type: 'TYPE_NAME', //Optional - default is googleSheet. Used for graphql queries.
+        // type: 'TYPE_NAME', // Optional - default is googleSheet. Used for graphql queries.
+        // range: 'A1:Z1000', // Optional - default should encompass all cells in a sheet. Specific tabs in a sheet can be specified like 'tab_name!A1:Z1000'.  
       }
     }
   ]

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ class GoogleSheetSource {
       sheetId: '',
       apiKey: '',
       type: 'googleSheet',
+      range: 'A1:ZZ10000',
     }
   }
 
@@ -25,7 +26,7 @@ class GoogleSheetSource {
       await sheets.spreadsheets.values
         .get({
           spreadsheetId: this.options.sheetId,
-          range: 'A1:ZZ10000',
+          range: this.options.range,
         })
         .then(response => {
           const data = response.data.values
@@ -36,7 +37,7 @@ class GoogleSheetSource {
               {}
             )
           })
-          nodes.map((value, key, title) => {
+          nodes.map((value) => {
             contentType.addNode(value)
           })
         })


### PR DESCRIPTION
This opens up the ability to not only specify a specific range of cells in a sheet, it allows a user to specify which tab in a sheet that has multiple tabs. Falls back to what the default range option was before adding this new option.

An example of specifying a tab within a sheet would be `vendors!A1:B1000`.